### PR TITLE
Set jwtSecret to use environment variable

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -9,7 +9,7 @@ export default defineNuxtConfig({
     compatibilityDate: '2024-04-03',
     devtools: { enabled: true },
     runtimeConfig: {
-        jwtSecret: '' // Make sure this is set via env or directly here
+        jwtSecret: process.env.JWT_SECRET // Make sure this is set via env or directly here
     },
     app: {
         head: {


### PR DESCRIPTION
Updated the jwtSecret configuration to securely pull its value from the JWT_SECRET environment variable. This improves security by keeping sensitive information out of the codebase.